### PR TITLE
failed timeout configuration. 

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
  
   forbidOnly: !!process.env.CI,
   
-  retries: 2,
+  retries: 0,
   
   workers: process.env.CI ? 1 : undefined,
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,8 +1,7 @@
-Details about the Automation testing assigment:
+|Things to do:
 
-Test is written with Typescript on the Playwright framework.
-Used VS Code program to write code.
-Test is flaky and may need to be run several times to pass successfully.
-Performed only on the Chromium Browser and in the headed mode.
-Tests are running faster than the page is loaded. And since I could not figure out how to upload config file, in the tests there will be couple lines with waitForTimeout() function.
-The best way to reproduce the test is: 6.1 To download Playwright to local computer by command "npm init playwright@latest" 6.2 Update config file, to comment out all browsers except chromium 6.3 Run the test using the buttons in the testing tab.
+1. Write test where failed payment with credit card is initiated (done)
+2. Remove timeouts from the tests and configure timeouts in the config file if necessary (-)
+3. Place variables with data in the separate file
+4. Place different tests in different files
+5. Enable other browser testing, perform headless testing, create execution scripts, to run the test on terminal


### PR DESCRIPTION
Failed timeout configuration
During test run /stepper url occurs, which triggers failing tests
Readme file updated. Which displays key tasks to do.